### PR TITLE
Eliminate Shift Conflicts

### DIFF
--- a/app/controllers/scheduler/schedule_previews_controller.rb
+++ b/app/controllers/scheduler/schedule_previews_controller.rb
@@ -4,11 +4,13 @@ module Scheduler
     def show
       authorize :schedule_preview, :show?
       @schedule = Scheduler::Schedule.for(current_company)
+      @locations = policy_scope(Location)
     end
 
     def create
       authorize :schedule_preview, :create?
-      @schedule = ::Schedule.new(company: current_company)
+      location = current_company.locations.find(params[:location_id])
+      @schedule = ::Schedule.new(company: current_company, location: location)
     end
 
     private

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,6 +2,7 @@ class Schedule
   include ActiveModel::Model
 
   attr_accessor :company
+  attr_accessor :location
 
   def schedule
     @_schedule ||= create_schedule
@@ -19,7 +20,7 @@ class Schedule
   private
 
   def create_schedule
-    Scheduler::Schedule.for(company)
+    Scheduler::Schedule.for(company, location)
   end
 
   def generate_schedule

--- a/app/models/scheduler/eligibility_finder.rb
+++ b/app/models/scheduler/eligibility_finder.rb
@@ -1,8 +1,9 @@
 module Scheduler
   class EligibilityFinder
-    def initialize(layout:, timeslot:)
+    def initialize(layout:, timeslot:, existing_shifts:)
       @layout = layout
       @timeslot = timeslot
+      @existing_shifts = existing_shifts
     end
 
     def find
@@ -17,15 +18,31 @@ module Scheduler
         adjacent_employees.delete(employee)
       end
 
-      adjacent_employees
+      adjacent_employees.each do |employee|
+        if @existing_shifts.user_scheduled_at(employee.id, timeslot.x, timeslot.y)
+          adjacent_employees.delete(employee);
+        end
+      end
+
+      remove_conflicts(adjacent_employees)
     end
 
     private
 
-    attr_reader :layout, :timeslot
+    attr_reader :layout, :timeslot, :existing_shifts
 
     def get_timeslot(x, y)
       layout.get_timeslot(x, y)
+    end
+
+    def remove_conflicts (employees)
+      employees.each do |employee|
+        if existing_shifts.user_scheduled_at(employee.id, timeslot.x, timeslot.y)
+          employees.delete(employee);
+        end
+      end
+
+      employees
     end
 
     def adjacent_employees

--- a/app/models/scheduler/existing_shifts.rb
+++ b/app/models/scheduler/existing_shifts.rb
@@ -1,0 +1,54 @@
+module Scheduler
+  class ExistingShifts
+    def initialize(company, date_start, timeslot_minute_range=15)
+      @date_start = date_start.strftime('%Y%m%d').to_i
+      @shifts = Shift.where("date >= #{@date_start}", company_id: company.id)
+      @timeslot_minute_range = timeslot_minute_range
+      parse_shifts
+    end
+
+    def user_scheduled_at(user_id, x, y)
+      timeslot_id = "#{x},#{y}"
+      if existing_timeslots.key? timeslot_id
+        existing_timeslots[timeslot_id].include? user_id
+      else
+        false
+      end
+    end
+
+    private
+
+    def parse_shifts
+      @shifts.each do |shift|
+        x = get_day_integer(shift.date)
+
+        y_start = get_time_integer(shift.minute_start)
+        y_end = get_time_integer(shift.minute_end)-1
+
+        (y_start..y_end).each do |y|
+          timeslot_id = "#{x},#{y}"
+          user_id = shift.user_location.user_id
+
+          if existing_timeslots.key? timeslot_id
+            existing_timeslots[timeslot_id].push(user_id) unless existing_timeslots[timeslot_id].include? user_id
+          else
+            existing_timeslots[timeslot_id] = [user_id]
+          end
+        end
+      end
+    end
+
+    def get_day_integer (date_integer)
+      date_integer - @date_start
+    end
+
+    def get_time_integer (minute_start)
+      minute_start/@timeslot_minute_range
+    end
+
+    def existing_timeslots
+      @_existing_timeslots ||= {}
+    end
+
+  end
+end

--- a/app/models/scheduler/options.rb
+++ b/app/models/scheduler/options.rb
@@ -1,7 +1,7 @@
 module Scheduler
   class Options
     DEFAULTS = {
-      allow_zero_shifts: true,
+      allow_zero_shifts: false,
       days_to_schedule: 7,
       time_interval_minutes: 15,
       find_shift_alternative: false,

--- a/app/models/scheduler/schedule.rb
+++ b/app/models/scheduler/schedule.rb
@@ -5,16 +5,19 @@ module Scheduler
     include ActiveSupport
 
     attr_accessor :company
+    attr_accessor :location
 
-    def self.for(company, schedule_start=Date.today, day_range=4, time_range=4)
-      schedule = new(company, schedule_start, day_range, time_range)
+    def self.for(company, location={}, schedule_start=Date.today, day_range=4, time_range=4)
+      schedule = new(company, location, schedule_start, day_range, time_range)
       schedule
     end
 
-    def initialize(company, schedule_start, day_range, time_range)
+    def initialize(company, location, schedule_start, day_range, time_range)
       # time_range needs looked into and removed / updated to interval minutes
       @options = Options.new(start_date: schedule_start, options: { days_to_schedule: day_range })
       @company = company
+      @location = location
+      @schedule_start = schedule_start
     end
 
     def generate
@@ -43,7 +46,7 @@ module Scheduler
 
     def employee_assigner
       @_employee_assigner ||= EmployeeAssigner.
-        new(company: company, layout: layout, options: options)
+        new(company: company, location: location, layout: layout,  date_start: @schedule_start, options: options)
     end
 
     def employees
@@ -52,7 +55,7 @@ module Scheduler
 
     def generate_shifts
       ShiftGenerator.
-        new(company: company, layout: layout, options: options).
+        new(company: company, location: location, layout: layout, options: options).
         generate
     end
 

--- a/app/models/scheduler/shift_generator.rb
+++ b/app/models/scheduler/shift_generator.rb
@@ -1,7 +1,8 @@
 module Scheduler
   class ShiftGenerator
-    def initialize(company:, layout:, options:)
+    def initialize(company:, location:, layout:, options:)
       @company = company
+      @location = location
       @layout = layout
       @options = options
     end
@@ -52,8 +53,7 @@ module Scheduler
         date_integer = date.strftime('%Y%m%d').to_i
 
         employee = employees.find(shift["employee_id"])
-        user_location = location.user_locations.find_by! user_id: employee.id
-
+        user_location = @location.user_locations.find_by! user_id: employee.id, location: @location
         shifts.push(company.shifts.build(user_location: user_location,
                                company: @company,
                                date: date_integer,
@@ -70,10 +70,6 @@ module Scheduler
 
     def timeslot(x=0, y=0)
       layout.get_timeslot(x, y)
-    end
-
-    def location
-      company.locations.first
     end
 
     def employees

--- a/app/models/scheduler/timeslot.rb
+++ b/app/models/scheduler/timeslot.rb
@@ -25,7 +25,7 @@ module Scheduler
     end
 
     def print
-      printf "[ %{slots_available} %{employees} ]" % {slots_available: @slots_available,
+      printf "[(#{@x},#{@y}) %{slots_available} %{employees} ]" % {slots_available: @slots_available,
                                                       employees: @employees.map { |e| e[:given_name]} }
     end
 

--- a/app/views/scheduler/schedule_previews/show.html.erb
+++ b/app/views/scheduler/schedule_previews/show.html.erb
@@ -8,9 +8,22 @@
     <article>
       <%= t(".description") %>
       <div>
-        <%= simple_form_for @schedule, url: scheduler_schedule_preview_path do |f| %>
-          <%= f.submit %>
-        <% end %>
+        <table>
+          <tbody>
+          <% @locations.each_with_index do |location, index| %>
+            <%= simple_form_for @schedule, url: scheduler_schedule_preview_path do |f| %>
+              <%= hidden_field_tag(:location_id, location.id) %>
+              <tr>
+                <td><%= location.name %></td>
+                <td><%= location.line_1 %></td>
+                <td><%= location.city %></td>
+                <td><%= location.county_province %></td>
+                <td><%= f.submit %></td>
+              </tr>
+            <% end %>
+          <% end %>
+          </tbody>
+        </table>
       </div>
     </article>
 

--- a/config/locales/scheduler/schedule_previews/en.yml
+++ b/config/locales/scheduler/schedule_previews/en.yml
@@ -4,6 +4,6 @@ en:
       show:
         title: New Schedule
         description: >
-          You don't have a schedule right now. Let's add one!
+          Select a location to create a schedule for!
       create:
         title: Preview of your Schedule


### PR DESCRIPTION
Added existing schedules class to parse shifts
User now can no longer be scheduled if they are already scheduled in another location or similar location
This allows for cross location scheduling and filling in already set up shift schedules

In the future I will write a class to handle the parsing of shifts by themselves so it can be used elsewhere.