### PR TITLE
Scheduling Constraints

### DIFF
--- a/app/models/scheduler/layout_generator.rb
+++ b/app/models/scheduler/layout_generator.rb
@@ -1,13 +1,14 @@
 module Scheduler
   class LayoutGenerator
-    def self.for(schedule, options)
-      new(schedule: schedule, options: options).generate
+    def self.for(schedule, rules, options)
+      new(schedule: schedule, rules: rules, options: options).generate
     end
 
-    def initialize(schedule:, layout_class: Scheduler::Layout, options: Options.new)
+    def initialize(schedule:, layout_class: Scheduler::Layout, rules:, options: Options.new)
       @schedule = schedule
       @layout_class = layout_class
       @options = options
+      @rules = rules
     end
 
     def generate
@@ -15,7 +16,7 @@ module Scheduler
         day = []
 
         (0..options.number_of_intervals).each do |interval_number|
-          day.push(Timeslot.new(day_number, interval_number, shift_allotment))
+          day.push(Timeslot.new(day_number, interval_number, shift_allotment(interval_number), rules, options))
         end
 
         layout.add_day(day)
@@ -26,18 +27,24 @@ module Scheduler
 
     private
 
-    def shift_allotment
-      if options.allow_zero_shift
-        0 + rand(options.shift_range + 1)
-      else
-        1 + rand(options.shift_range)
+    def shift_allotment(interval_number)
+      allocation = 0
+      rules.each do |rule|
+        allocation = allocation + rule.number_of_employees if rule_within_bounds(rule.period, interval_number)
       end
+      allocation
+    end
+
+    def rule_within_bounds(rule_period, interval)
+      interval_minutes = interval*options.time_interval_minutes
+      rule_timeframe = options.period_timeframes(rule_period)
+      interval_minutes >= rule_timeframe[:start] && interval_minutes < rule_timeframe[:end]
     end
 
     def layout
       @_layout ||= layout_class.new(options)
     end
 
-    attr_reader :options, :layout_class, :schedule
+    attr_reader :options, :layout_class, :schedule, :rules
   end
 end

--- a/app/models/scheduler/minmax_shift_helper.rb
+++ b/app/models/scheduler/minmax_shift_helper.rb
@@ -1,0 +1,72 @@
+module Scheduler
+  class MinmaxShiftHelper
+
+    def initialize(timeslot:, employee:, layout:, company:, options:)
+      @timeslot = timeslot
+      @employee = employee
+      @layout = layout
+      @company = company
+      @options = options
+    end
+
+    def is_not_eligible
+      exceeds_maximum = false
+      fails_minumum = false
+      if !company_preference.minimum_shift_length.nil?
+        fails_minumum = false;
+      end
+
+      if !company_preference.maximum_shift_length.nil?
+        exceeds_maximum = would_exceed_max
+      end
+
+      exceeds_maximum || fails_minumum
+    end
+
+    private
+
+    attr_reader :timeslot
+    attr_reader :employee
+    attr_reader :layout
+    attr_reader :company
+    attr_reader :options
+
+    def company_preference
+      company.company_preference
+    end
+
+    def would_exceed_max
+      # up direction
+      assigned = true
+      up_shift_length = 0
+      next_up_timeslot = timeslot
+      while assigned
+        next_y = next_up_timeslot.y-1
+        next_up_timeslot = layout.get_timeslot(timeslot.x, next_y)
+        if next_up_timeslot && next_up_timeslot.has_employee?(employee.id)
+          up_shift_length = up_shift_length + 1
+        else
+          assigned = false;
+        end
+      end
+
+      # down direction
+      assigned = true
+      down_shift_length = 0
+      next_down_timeslot = timeslot
+      while assigned
+        next_y = next_down_timeslot.y+1
+        next_down_timeslot = layout.get_timeslot(timeslot.x, next_y)
+        if next_down_timeslot && next_down_timeslot.has_employee?(employee.id)
+          down_shift_length = down_shift_length + 1
+        else
+          assigned = false;
+        end
+      end
+
+      sum_possible = up_shift_length + down_shift_length + 1
+      sum_possible*options.time_interval_minutes > company_preference.maximum_shift_length
+    end
+
+  end
+end

--- a/app/models/scheduler/options.rb
+++ b/app/models/scheduler/options.rb
@@ -8,7 +8,37 @@ module Scheduler
       none_eligible_strategy: "IGNORE",
       random_block_start_req: 20,
       start_priority: 0,
-      shift_range: 3 # what is this?
+      shift_range: 3, # what is this?
+      period_timeframes: {
+        "open" => {
+          start: 9*60,
+          end: 12*60
+        },
+        "close" => {
+          start: 13*60,
+          end: 18*60
+        },
+        "all_day" => {
+          start: 9*60,
+          end: 18*60
+        },
+        "lull" => {
+          start: 9*60,
+          end: 18*60
+        },
+        "normal" => {
+          start: 9*60,
+          end: 18*60
+        },
+        "busy" => {
+          start: 9*60,
+          end: 18*60
+        },
+        "peak" => {
+          start: 9*60,
+          end: 18*60
+        }
+      }
     }
 
     def initialize(start_date:, options: {})
@@ -42,6 +72,10 @@ module Scheduler
 
     def shift_range
       options[:shift_range]
+    end
+
+    def period_timeframes(id)
+      options[:period_timeframes]["#{id}"]
     end
 
     private

--- a/app/models/scheduler/schedule.rb
+++ b/app/models/scheduler/schedule.rb
@@ -23,6 +23,7 @@ module Scheduler
     def generate
       employee_assigner.assign
       generate_shifts
+      print
     end
 
     # called from view
@@ -59,8 +60,12 @@ module Scheduler
         generate
     end
 
+    def schedule_rules
+      @_schedule_rules ||= company.schedule_rules
+    end
+
     def layout
-      @_layout ||= LayoutGenerator.for(self, options)
+      @_layout ||= LayoutGenerator.for(self, schedule_rules, options)
     end
   end
 end

--- a/app/models/scheduler/timeslot.rb
+++ b/app/models/scheduler/timeslot.rb
@@ -4,12 +4,20 @@ module Scheduler
     attr_reader :x
     attr_reader :y
     attr_reader :employees
+    attr_reader :position_slots
+    attr_reader :position_employees
+    attr_reader :options
 
-    def initialize(x, y, slots_available)
+    def initialize(x, y, slots_available, rules, options)
       @x = x
       @y = y
       @slots_available = slots_available
       @employees = []
+      @position_slots = {}
+      @position_employees = {}
+      @options = options
+
+      read_rule_slots(rules)
     end
 
     def full
@@ -20,8 +28,53 @@ module Scheduler
       !full
     end
 
-    def add_employee(employee)
+    def positions
+      position_slots.keys
+    end
+
+    def position_available?(employee)
+      space_available = false
+      employee.positions.each do |position|
+        space_available = space_available || (position_exists?(position.name) && position_room_available?(position.name))
+      end
+
+      space_available
+    end
+
+    def position_exists?(position_name)
+      position_slots.key? position_name
+    end
+
+    def position_room_available?(position_name)
+      if position_employees[position_name].nil?
+        false
+      else
+        position_employees[position_name].length < position_slots[position_name]
+      end
+    end
+
+    def add_employee(employee, position=nil)
       @employees.push(employee)
+      @position_employees[position].push(employee) if not position.nil?
+    end
+
+    def read_rule_slots(rules)
+      rules.each do |rule|
+        if rule_within_bounds(rule.period, y)
+          if position_slots.key? rule.position.name
+            position_slots[rule.position.name] = position_slots[rule.position.name] + 1
+          else
+            position_slots[rule.position.name] = 1
+            position_employees[rule.position.name] = []
+          end
+        end
+      end
+    end
+
+    def rule_within_bounds(rule_period, interval)
+      interval_minutes = interval*options.time_interval_minutes
+      rule_timeframe = options.period_timeframes(rule_period)
+      interval_minutes >= rule_timeframe[:start] && interval_minutes < rule_timeframe[:end]
     end
 
     def print

--- a/app/views/scheduler/schedule_previews/create.html.erb
+++ b/app/views/scheduler/schedule_previews/create.html.erb
@@ -14,6 +14,7 @@
             <th>Employee</th>
             <th>Minute Start</th>
             <th>Minute End</th>
+            <th>Shift Length (minutes)</th>
             <th>Minute Date</th>
           </tr>
         </thead>
@@ -33,6 +34,7 @@
             <td><%= shift.user_location.user.given_name %></td>
             <td><%= shift.minute_start %></td>
             <td><%= shift.minute_end %></td>
+            <td><%= shift.minute_end - shift.minute_start %></td>
             <td><%= shift.date %></td>
           <% end %>
 


### PR DESCRIPTION
1) Max schedule constraints are now used to limit shift lengths. This is done by assuming the timeslot is assigned and counting up and down timeslots and counting the number of consecutive timeslots then multiplying by minutes/interval
2) Fixed initial assignment loop. This would just timeout. Now it re-selects the next slot correctly and considers positions from a sample of the employees positions
3) Added Position Scheduling. Positions are not incorporated into timeslots and eligibility. Timeslots are aware of available timeslots for a position and assigners are sure to check these position slots before assigning.