### PR TITLE
Fixed disjointed scheduling with employee injections

### DIFF
--- a/app/models/scheduler/layout.rb
+++ b/app/models/scheduler/layout.rb
@@ -19,6 +19,17 @@ module Scheduler
       @day_shift_grid.push(day)
     end
 
+    def all_slots_full?
+      all_full = true
+      @day_shift_grid.each do |day_shifts|
+        day_shifts.each do |slot|
+          all_full = slot.full? && all_full
+        end
+      end
+
+      all_full
+    end
+
     private
 
     attr_reader :options

--- a/app/models/scheduler/timeslot.rb
+++ b/app/models/scheduler/timeslot.rb
@@ -20,12 +20,12 @@ module Scheduler
       read_rule_slots(rules)
     end
 
-    def full
+    def full?
       @employees.length == @slots_available
     end
 
     def not_full?
-      !full
+      !full?
     end
 
     def positions


### PR DESCRIPTION
If we get into a 'stuck' state, the algorithm knows to re-run the iteration checking
by taking the unfilled slots and finding an eligible employee for that slot
If the injection is successful - the algorithm resumes scheduling

The iteration procedure has also changed.
Before this moment, a user who was placed as part of the initial preparation into the last day
would more often than not be stuck with a 15 minute shift. This is because the iteration is from
day 0 until day n, time 0 to time k
To fix this the timeslots in each day for the iteration machine are now randomized, as are the days
Now a user in day n has equal probability to be scheduled for a adjacent shift as a user in day 0

The next step is to adjust eligibility to determine how to limit 30 minute shifts from being
'normal' to the algorithm