### PR TITLE
Shift Finder No Longer Respected User Id

### DIFF
--- a/app/controllers/mobile_api/future_shifts_controller.rb
+++ b/app/controllers/mobile_api/future_shifts_controller.rb
@@ -1,7 +1,7 @@
 module MobileApi
   class FutureShiftsController < ApiAuthenticatedController
     def show
-      future_shifts = ShiftFinder.for(current_user).future
+      future_shifts = ShiftFinder.for(current_user).future.find
 
       render json: { future_shifts: future_shifts }, status: :ok
     end

--- a/app/models/location_schedule.rb
+++ b/app/models/location_schedule.rb
@@ -13,7 +13,7 @@ class LocationSchedule
   end
 
   def shifts_for(user)
-    user.shifts.where(location: location)
+    ShiftFinder.for(location).on(date).worked_by(user).find
   end
 
   def shifts?
@@ -29,6 +29,6 @@ class LocationSchedule
   end
 
   def find_shifts
-    ShiftFinder.for(location).on(date)
+    ShiftFinder.for(location).on(date).find
   end
 end

--- a/app/models/shift_finder.rb
+++ b/app/models/shift_finder.rb
@@ -5,23 +5,45 @@ class ShiftFinder
 
   def initialize(object:)
     @object = object
+    self.scope = all
+  end
+
+  def find
+    scope
+  end
+
+  def worked_by(user)
+    self.scope = scope.where(user_id: user.id)
+    self
   end
 
   def next
-    future.first
+    self.scope = future.find.first
+    self
   end
 
   def on(date=Date.today)
-    all.where(date: date.strftime('%Y%m%d').to_i)
+    self.scope = scope.where(date: date.strftime('%Y%m%d').to_i)
+    self
   end
 
   def future
     # these shifts drop off 15 minutes after they over
-    all.
+    self.scope = scope.
       where(date: (current_day+1..Float::INFINITY)).
       or(all.
          where(date: current_day, minute_end: ((current_minute - 15)..1440)))
+    self
   end
+
+  def find_by(options)
+    scope.find_by(options).find
+  end
+
+  private
+
+  attr_accessor :scope
+  attr_reader :object
 
   def all
     object.
@@ -29,14 +51,6 @@ class ShiftFinder
       active.
       order(:date, :minute_start)
   end
-
-  def find_by(options)
-    all.find_by(options)
-  end
-
-  private
-
-  attr_reader :object
 
   def current_day
     Date.today.to_s(:number).to_i

--- a/app/policies/shift_policy.rb
+++ b/app/policies/shift_policy.rb
@@ -1,7 +1,7 @@
 class ShiftPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      ShiftFinder.for(user).future
+      ShiftFinder.for(user).future.find
     end
   end
 end

--- a/app/presenters/calendar_show_presenter.rb
+++ b/app/presenters/calendar_show_presenter.rb
@@ -16,7 +16,7 @@ class CalendarShowPresenter
   end
 
   def next_shift
-    @_next_shift ||= ShiftFinder.for(user).next
+    @_next_shift ||= ShiftFinder.for(user).next.find
   end
 
   def next_shift_partial

--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -3,7 +3,7 @@
 
   <%= f.input :offered_shift_id,
     as: :select,
-    collection: ShiftFinder.for(current_user).future,
+    collection: ShiftFinder.for(current_user).future.find,
     label_method: :selection_label %>
 
   <%= f.submit %>


### PR DESCRIPTION
Previously location and user were tied together in user locations. Now
they are determined by user_id and location_id on shift. I am updating
shiftfinder to retain a reference to scope so you can use it to chain
query methods. Calling a .find method will then return that scope to be
used.