### PR TITLE
Show KB instead of live chat when user clicks chat bubble

### DIFF
--- a/app/views/layouts/shared/_reamaze.html.erb
+++ b/app/views/layouts/shared/_reamaze.html.erb
@@ -6,18 +6,19 @@
 <script type="text/javascript">
   var _support = _support || { 'ui': {}, 'user': {} };
   _support['account'] = 'scheduleless';
-  _support['ui']['anonymousMode'] = 'anonymous';
+  _support['ui']['anonymousMode'] = 'mixed';
   _support['ui']['enableKb'] = 'true';
   _support['ui']['styles'] = {
     widgetColor: 'rgb(102, 149, 251)',
   };
+  _support['ui']['lightbox_mode'] = 'kb';
   _support['ui']['widget'] = {
     icon: 'chat',
     label: {
-      text: '<%= t(".label_text") %> 😊',
+      text: '<%= t(".label_text") %>',
       mode: "prompt-3",
-      delay: 3,
-      duration: 20,
+      delay: 5,
+      duration: 10,
     },
     position: 'bottom-right',
   };


### PR DESCRIPTION
This change will open knowledge base articles instead of the live chat when the user clicks on the chat bubble button. The user can then click on the contact button to start the live chat. The purpose is to make it a self-serve support center and reduce direct contact. 