### PR TITLE
Update chat bubble to start with live chat instead of KB articles

### DIFF
--- a/app/views/layouts/shared/_reamaze.html.erb
+++ b/app/views/layouts/shared/_reamaze.html.erb
@@ -6,18 +6,17 @@
 <script type="text/javascript">
   var _support = _support || { 'ui': {}, 'user': {} };
   _support['account'] = 'scheduleless';
-  _support['ui']['anonymousMode'] = 'mixed';
+  _support['ui']['anonymousMode'] = 'anonymous';
   _support['ui']['enableKb'] = 'true';
   _support['ui']['styles'] = {
     widgetColor: 'rgb(102, 149, 251)',
   };
-  _support['ui']['lightbox_mode'] = 'kb';
   _support['ui']['widget'] = {
     icon: 'chat',
+    size: 47,
     label: {
-      text: '<%= t(".label_text") %>',
       mode: "prompt-3",
-      delay: 5,
+      delay: 5000,
       duration: 10,
     },
     position: 'bottom-right',


### PR DESCRIPTION
This change will start the live chat instead of showing KB articles when a user clicks on the chat bubble. We will switch back to KB articles as soon as we have them written down. It will also remove the prompt that offers help in German. 