### PR TITLE
Dismiss comma if location line 2 is not filled in

### DIFF
--- a/app/models/address_formatter.rb
+++ b/app/models/address_formatter.rb
@@ -10,7 +10,7 @@ class AddressFormatter
   end
 
   def address
-    [location.line_1, location.line_2, location.line_3].compact
+    [location.line_1, location.line_2, location.line_3].reject(&:blank?)
   end
 
   def calendar_stream

--- a/app/views/onboarding/locations/index.html.erb
+++ b/app/views/onboarding/locations/index.html.erb
@@ -8,7 +8,7 @@
     <% @locations.each do |location| %>
       <tr>
         <td>
-          <%= AddressFormatter.for(location).address.reject(&:blank?).join(", ") %>
+          <%= AddressFormatter.for(location).address.join(", ") %>
         </td>
         <td>
           <%= AddressFormatter.for(location).city_state_zip %>


### PR DESCRIPTION
This change will remove the comma between address line 1 and address line 2 during the onboarding process if address line 2 is not filled in by the customer. 