### PR TITLE
Internationalizations for Calendars Views (with a fix)

### DIFF
--- a/app/views/calendars/_day_schedule.html.erb
+++ b/app/views/calendars/_day_schedule.html.erb
@@ -29,8 +29,8 @@
       Schedule for <%= presenter.date.to_s(:month_day_year) %>
 
       <aside>
-        <%= link_to "New Shift",
-          new_locations_location_shift_path(date: presenter.date.to_s)
+        <%= link_to t(".new_shift"),
+          new_locations_location_shift_path(presenter.date.to_s)
         %>
       </aside>
     </div>
@@ -51,15 +51,15 @@
           ) %>
       <% else %>
         <div class="empty-schedule">
-          No shifts are scheduled for today.
+          <%= t(".empty_schedule") %>
 
           <% if policy(:scheduling_period).create? %>
             <br>
-            <%= link_to("Create a Schedule",
+            <%= link_to( t(".create_a_schedule"),
               locations_location_scheduling_periods_path(
                 presenter.current_location
-              )
-             ) %>
+                )
+              ) %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/calendars/_week_schedule.html.erb
+++ b/app/views/calendars/_week_schedule.html.erb
@@ -44,7 +44,7 @@
                 <% else %>
                   <% if presenter.preview %>
                     <%= link_to(
-                      "Add",
+                      t(".add"),
                       new_locations_location_in_progress_shift_path(
                         presenter.location,
                         scheduling_period_id: presenter.scheduling_period.id,

--- a/config/locales/calendars/en.yml
+++ b/config/locales/calendars/en.yml
@@ -9,6 +9,10 @@ en:
         Click here to review and approve your upcoming schedules
       time_off_approvals: >
         Click here to review pending time off requests
+    day_schedule:
+      new_shift: "New Shift"
+      empty_schedule: No shifts are scheduled for today.
+      create_a_schedule: "Create a Schedule"
     location_select:
       selected_location: "Selected Location"
     next_shift:
@@ -16,8 +20,10 @@ en:
       check_out: "Check Out"
     no_locations:
       contact_manager: >
-        Contact your manager to ensure you get added to your proper location so 
+        Contact your manager to ensure you get added to your proper location so
         you can start receiving more hours!
       not_added: >
-        You haven't been added to any locations yet! You probably won't be able 
+        You haven't been added to any locations yet! You probably won't be able
         to see much.
+    week_schedule:
+      add: "Add!"


### PR DESCRIPTION
…views.

1. Added changes to en.yml for calendars.
2.  Added three internationalizations in day_schedule partial
3. Added one internationalization in week_schedule partial
4. Added a fix in day_schedule partial. I could not access the new_locations_locations_shift_path until I removed the "date: " that was in front of presenter.date.to_s in front of it. Only then could I move to the next page:

Before: new_locations_location_shift_path(date: presenter.date.to_s)
After: new_locations_location_shift_path(presenter.date.to_s)