### PR TITLE
Internationalizations for Dashboards views (with questions)

### DIFF
--- a/app/views/dashboards/_approvals.html.erb
+++ b/app/views/dashboards/_approvals.html.erb
@@ -1,13 +1,13 @@
 <div class="frame dashboard-approvals">
   <header class="light">
-    <div>Approvals (Managers Only)</div>
+    <div><%= t(".approvals") %></div>
   </header>
 
   <section>
     <div class="empty-message">
-      <h3>You're caught up!</h3>
+      <h3><%= t(".caught_up")%></h3>
       <span class="oi oi-circle-check"></span>
-      <p>We'll let you know when something comes up. Enjoy the downtime!</p>
+      <p><%= t(".downtime") %></p>
     </div>
   </section>
 </div>

--- a/app/views/dashboards/_available_shifts.html.erb
+++ b/app/views/dashboards/_available_shifts.html.erb
@@ -1,17 +1,17 @@
 <div class="frame fill">
   <header class="light">
-    <div>Available Shifts</div>
+    <div><%= t(".available_shifts") %></div>
   </header>
 
   <section>
     <% if [].blank? %>
       <div class="empty-message">
-        <h3>No Shifts Are Available</h3>
-        Looking for more hours?<br />
-        <%= link_to "Adjust your availability preferences.", edit_user_path %>
+        <h3><%= t(".no_shifts") %></h3>
+        <%= t(".looking") %><br />
+        <%= link_to t(".adjust_availability"), edit_user_path %>
       </div>
     <% else %>
-      there are some shifts!
+      <%= t(".there_are_shifts") %>
     <% end %>
   </section>
 </div>

--- a/app/views/dashboards/_upcoming_shift.html.erb
+++ b/app/views/dashboards/_upcoming_shift.html.erb
@@ -1,10 +1,10 @@
 <div class="dashboard-upcoming-shift">
-  <h3>Upcoming Shift</h3>
+  <h3><%= t(".upcoming_shifts") %></h3>
   <div>
     July
     <section>20</section>
     9am - 5pm
 
-    <button>Check In</button>
+    <button><%= t(".check_in") %></button>
   </div>
 </div>

--- a/app/views/dashboards/_whose_working.html.erb
+++ b/app/views/dashboards/_whose_working.html.erb
@@ -1,7 +1,7 @@
 <div class="frame fill">
   <header class="light">
     <div>
-      Whose Working?
+      <%= t(".whose_working") %>
     </div>
   </header>
 
@@ -14,7 +14,7 @@
       <% end %>
     <% else %>
       <div class="empty-message">
-        <h3>We're closed right now!</h3>
+        <h3><%= t(".closed") %></h3>
         <span class="oi oi-moon"></span>
         <p>We open at 9am on Tuesday.</p>
       </div>

--- a/config/locales/dashboards/en.yml
+++ b/config/locales/dashboards/en.yml
@@ -1,0 +1,18 @@
+en:
+  dashboards:
+    approvals:
+      approvals: "Approvals (Managers Only)"
+      caught_up: "You're caught up!"
+      downtime: "We'll let you know when something comes up. Enjoy the downtime!"
+    available_shifts:
+      adjust_availability: "Adjust your availability preferences."
+      available_shifts: "Available Shifts"
+      looking: "Looking for more hours?"
+      no_shifts: "No Shifts Are Available"
+      there_are_shifts: "There are some shifts!"
+    upcoming_shift:
+      check_in: Check In
+      upcoming_shifts: Upcoming Shift
+    whose_working:
+      closed: We're closed right now!
+      whose_working: Whose Working?


### PR DESCRIPTION
-Changes to four partials in dashboards/views:
  1. approvals
  2. available shifts
  3. upcoming shift
  4. whose working
- New en.yml in config/locals/dashboards

-Question: 
-In available shifts:
1. Line 14, I made "there are some shifts" internationalized. Is that just a placeholder?

-In whose working:
1. Line 12. Is "this is a shift" just a placeholder, or should it be internationalized?
2. LIne 19. How should I handle internationalizing this line? I get the sense that the time that a company is open is determined during sign-up, but I don't see how it is feeding in. I thought about perhaps doing two internationalizations on this line:

#{t(".we_open_at") 9am t(".on_day}"  

The on_day would need to internationalize the day depending on the day, so I assume that will be interpolated in the en.yml. However, since Tuesday (like 9am) isn't coming from a variable I can see, I'm not sure what to do on this one. Let me know how to handle this line. 
